### PR TITLE
Reload buffer only when secret length is not reached

### DIFF
--- a/src/shifty.ts
+++ b/src/shifty.ts
@@ -79,14 +79,16 @@ export default class Shifty {
    */
   generate(length?: number): string {
     length = length ? length : this.defaultLength;
-
-    this.populateBuffer();
+    
     let secret = "";
 
     // The while loop ensures we always satisfy the length condition
     // If the inner loop ends before we have the password of the required length
     // the while loop will restart the inner loop
     while (secret.length < length) {
+      // generate a new buffer everytime to ensure we don't end up with repeating values
+      this.populateBuffer();
+      
       for (
         let rollIndex = 0;
         rollIndex < this.randomBuffer.length;
@@ -103,10 +105,7 @@ export default class Shifty {
           break;
         }
       }
-      // generate a new buffer to ensure we don't end up with repeating values
-      this.populateBuffer();
     }
-
     return secret;
   }
 

--- a/src/shifty.ts
+++ b/src/shifty.ts
@@ -79,7 +79,7 @@ export default class Shifty {
    */
   generate(length?: number): string {
     length = length ? length : this.defaultLength;
-    
+
     let secret = "";
 
     // The while loop ensures we always satisfy the length condition
@@ -88,7 +88,7 @@ export default class Shifty {
     while (secret.length < length) {
       // generate a new buffer everytime to ensure we don't end up with repeating values
       this.populateBuffer();
-      
+
       for (
         let rollIndex = 0;
         rollIndex < this.randomBuffer.length;


### PR DESCRIPTION
## Description

This change improves the secret generation algorithm by not calling the buffer population method when the secret length is met.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes in this PR

- Repositioned the `populateBuffer` method, to be called when the random buffer loop exits prematurely without completing the secret length

## Checklist before merging

(Add to-do for reviewers and you to track, keep the PR in draft until all to-dos are cleared)

- [ ] Tests
- [ ] Code and Readme documentation

## Note to reviewers (Optional)

(Anything that the reviewer should keep in mind)
