### PR TITLE
Migrate GitHub Actions to Blacksmith runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions workflows from GitHub-hosted runners to Blacksmith runners
- Delete unused/deprecated workflow files where applicable
- Heavy workflows (builds, tests, Docker) use `blacksmith-4vcpu-ubuntu-2404`
- Light workflows (dispatch, lint, sync) use `blacksmith-2vcpu-ubuntu-2404`
- macOS, Windows, and self-hosted runners are left unchanged

## Related
- ENG-4173 (Blacksmith migration)
- ENG-4174 (Workflow cleanup)